### PR TITLE
Separate out the JSON and CBOR specific parts of the CDDL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ kramdown-rfc2629 ?= kramdown-rfc2629
 
 
 DRAFT = draft-ietf-core-senml
-VERSION = 00
+VERSION = 01
 
 .PHONY: latest txt html pdf  diff clean check 
 
@@ -58,11 +58,11 @@ $(DRAFT)-$(VERSION).xml: $(DRAFT).md ex1.gen.exi.hex ex1.gen.xml ex1.json ex10.j
 %.chk: %.xml senml.rnc
 	java -jar bin/jing.jar -c senml.rnc $< > $@
 
-%.chk: %.json senml.cddl
-	cddl senml.cddl validate $<  > $@
+%.chk: %.json senml.cddl senml-json.cddl
+	cat senml.cddl senml-json.cddl | cddl - validate $<  > $@
 
-%.gen.cbor.chk: %.gen.cbor senml.cddl
-	cddl senml.cddl validate $<  > $@
+%.gen.cbor.chk: %.gen.cbor senml.cddl senml-cbor.cddl
+	cat senml.cddl senml-cbor.cddl | cddl - validate $<  > $@
 
 
 %.tmp.xsd: %.rnc 

--- a/draft-ietf-core-senml.md
+++ b/draft-ietf-core-senml.md
@@ -690,15 +690,29 @@ the situations listed above has happened.
 
 # CDDL
 
-For reference, the CBOR representation can be described with the CDDL 
-{{I-D.greevenbosch-appsawg-cbor-cddl}} specification in {{senmlcddl}}. 
+For reference, the JSON and CBOR representations can be described with
+the common CDDL
+{{I-D.greevenbosch-appsawg-cbor-cddl}} specification in {{senmlcddl}}.
 
-~~~~ cddl 
+~~~~ cddl
 {::include senml.cddl}
 ~~~~~
-{: #senmlcddl title="CDDL specification for CBOR SenML"}
+{: #senmlcddl title="Common CDDL specification for CBOR and JSON SenML"}
 
-TODO - seems to be a problem with CDDL not validating examples
+For JSON, we use text labels and base64url-encoded binary data ({{senmlcddl-json}}).
+
+~~~~ cddl
+{::include senml-json.cddl}
+~~~~~
+{: #senmlcddl-json title="JSON-specific CDDL specification for SenML"}
+
+For CBOR, we use integer labels and native binary data ({{senmlcddl-cbor}}).
+
+~~~~ cddl
+{::include senml-cbor.cddl}
+~~~~~
+{: #senmlcddl-cbor title="CBOR-specific CDDL specification for SenML"}
+
 
 # IANA Considerations
 

--- a/senml-cbor.cddl
+++ b/senml-cbor.cddl
@@ -1,0 +1,7 @@
+bver = -1  n  = 0   s  = 5
+bn  = -2   u  = 1   t  = 6
+bt  = -3   v  = 2   ut = 7
+bu  = -4   vs = 3   vd = 8
+bv  = -5   vb = 4
+
+binary-value = bstr

--- a/senml-json.cddl
+++ b/senml-json.cddl
@@ -1,0 +1,7 @@
+bver = "bver" n  = "n"   s  = "s"
+bn  = "bn"    u  = "u"   t  = "t"
+bt  = "bt"    v  = "v"   ut = "ut"
+bu  = "bu"    vs = "vs"  vd = "vd"
+bv  = "bv"    vb = "vb"
+
+binary-value = tstr             ; base64url encoded

--- a/senml-json2cbor.rb
+++ b/senml-json2cbor.rb
@@ -1,0 +1,64 @@
+require 'json'
+require 'cbor'
+
+MAPPINGS = Hash.new {|h, k| k}
+
+DATA.read.scan(/([-\w]+)\s*=\s*([-\w]+)/) do |n, v|
+  begin
+    MAPPINGS[n] = Integer(v)
+  rescue ArgumentError
+  end
+end
+
+# p MAPPINGS
+
+class Array
+  def cborify_senml
+    map(&:cborify_senml)
+  end
+end
+
+class Hash
+  def cborify_senml
+    Hash[map { |k, v|
+      [MAPPINGS[k], v.cborify_senml]
+    }]
+  end
+end
+
+# This hacks off precision to 10 bits of mantissa so CBOR can generate
+# half floats. Optional. Comment out if undesired.
+class Float
+  def cborify_senml
+    short = [[self].pack("g").unpack("N")[0] & 0xFFFFE000].pack("N").unpack("g")[0]
+    # warn [short, short.to_cbor.size].inspect
+    if short.to_cbor.size == 3
+      short
+    else
+      self
+    end
+  end
+end
+
+class Object
+  def cborify_senml
+    self
+  end
+end
+
+data = JSON.load(ARGF)
+# p data.cborify_senml
+print data.cborify_senml.to_cbor
+
+# Below, a copy of senml-cbor.cddl so this is a freestanding program;
+# need to remember to update this copy whenever we update
+# senml-cbor.cddl
+__END__
+
+bver = -1  n  = 0   s  = 5
+bn  = -2   u  = 1   t  = 6
+bt  = -3   v  = 2   ut = 7
+bu  = -4   vs = 3   vd = 8
+bv  = -5   vb = 4
+
+binary-value = bstr

--- a/senml.cddl
+++ b/senml.cddl
@@ -22,21 +22,13 @@ follow-on-defined-group = (
    ? ( v => numeric // ; Numeric Value
        vs => tstr //   ; String Value
        vb => bool //   ; Boolean Value
-       vd => bstr )    ; Data Value
+       vd => binary-value ) ; Data Value
    ? s => numeric,     ; Value Sum
    ? t => numeric,     ; Time
    ? ut => numeric,    ; Update Time
    * key-value-pair
 )
 follow-on-defined = { follow-on-defined-group }
-
-; CBOR version (use the labels)
-bver = -1  n  = 0   s  = 5
-bn  = -2   u  = 1   t  = 6
-bt  = -3   v  = 2   ut = 7
-bu  = -4   vs = 3   vd = 8
-bv  = -5   vb = 4
-; use the label *names* for JSON
 
 ; now define the generic versions
 
@@ -57,6 +49,5 @@ base-key-value-pair = ( b-label => value )
 non-b-label = tstr .regexp  "[A-Zac-z0-9][-_:.A-Za-z0-9]*" / uint
 b-label = tstr .regexp  "b[-_:.A-Za-z0-9]+" / nint
 
-value = tstr / bstr / numeric / bool
+value = tstr / binary-value / numeric / bool
 numeric = number / decfrac
- 


### PR DESCRIPTION
Doing the validations requires a  bugfix in the CDDL tool (gem update; should have 0.7.4 then).

Note that the one CBOR example in the repo passes because "bn" etc. are considered to be extensions (they should be integer labels).

Example 8 is broken JSON.
